### PR TITLE
log -> logrus

### DIFF
--- a/.github/scripts/build_instance/main.go
+++ b/.github/scripts/build_instance/main.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"os/signal"
 	"time"

--- a/.github/scripts/fetch_outputs/main.go
+++ b/.github/scripts/fetch_outputs/main.go
@@ -6,7 +6,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"os/signal"
 	"path/filepath"

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ package main
 import (
 	"context"
 	"flag"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"

--- a/tfe/data_source_ip_ranges.go
+++ b/tfe/data_source_ip_ranges.go
@@ -5,7 +5,7 @@ package tfe
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/tfe/data_source_organization.go
+++ b/tfe/data_source_organization.go
@@ -5,7 +5,7 @@ package tfe
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/tfe/data_source_organizations.go
+++ b/tfe/data_source_organizations.go
@@ -5,7 +5,7 @@ package tfe
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/tfe/data_source_outputs.go
+++ b/tfe/data_source_outputs.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"

--- a/tfe/data_source_slug.go
+++ b/tfe/data_source_slug.go
@@ -8,7 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 
 	slug "github.com/hashicorp/go-slug"

--- a/tfe/data_source_variables.go
+++ b/tfe/data_source_variables.go
@@ -5,7 +5,7 @@ package tfe
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/tfe/data_source_workspace.go
+++ b/tfe/data_source_workspace.go
@@ -5,7 +5,7 @@ package tfe
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/url"
 
 	tfe "github.com/hashicorp/go-tfe"

--- a/tfe/logging.go
+++ b/tfe/logging.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"net/http/httputil"
 	"os"

--- a/tfe/organization_members_helpers.go
+++ b/tfe/organization_members_helpers.go
@@ -6,7 +6,7 @@ package tfe
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	tfe "github.com/hashicorp/go-tfe"
 )

--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -8,7 +8,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"net/url"
 	"os"

--- a/tfe/resource_tfe_admin_organization_settings.go
+++ b/tfe/resource_tfe_admin_organization_settings.go
@@ -6,7 +6,7 @@ package tfe
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/tfe/resource_tfe_agent_pool.go
+++ b/tfe/resource_tfe_agent_pool.go
@@ -6,7 +6,7 @@ package tfe
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"

--- a/tfe/resource_tfe_agent_token.go
+++ b/tfe/resource_tfe_agent_token.go
@@ -5,7 +5,7 @@ package tfe
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/tfe/resource_tfe_notification_configuration.go
+++ b/tfe/resource_tfe_notification_configuration.go
@@ -5,7 +5,7 @@ package tfe
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/tfe/resource_tfe_oauth_client.go
+++ b/tfe/resource_tfe_oauth_client.go
@@ -5,7 +5,7 @@ package tfe
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/tfe/resource_tfe_organization.go
+++ b/tfe/resource_tfe_organization.go
@@ -5,7 +5,7 @@ package tfe
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"

--- a/tfe/resource_tfe_organization_membership.go
+++ b/tfe/resource_tfe_organization_membership.go
@@ -6,7 +6,7 @@ package tfe
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"

--- a/tfe/resource_tfe_organization_module_sharing.go
+++ b/tfe/resource_tfe_organization_module_sharing.go
@@ -5,7 +5,7 @@ package tfe
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"

--- a/tfe/resource_tfe_organization_run_task.go
+++ b/tfe/resource_tfe_organization_run_task.go
@@ -6,7 +6,7 @@ package tfe
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"

--- a/tfe/resource_tfe_organization_token.go
+++ b/tfe/resource_tfe_organization_token.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/tfe/resource_tfe_policy.go
+++ b/tfe/resource_tfe_policy.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/go-tfe"

--- a/tfe/resource_tfe_policy_set.go
+++ b/tfe/resource_tfe_policy_set.go
@@ -5,7 +5,7 @@ package tfe
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 
 	tfe "github.com/hashicorp/go-tfe"

--- a/tfe/resource_tfe_policy_set_parameter.go
+++ b/tfe/resource_tfe_policy_set_parameter.go
@@ -6,7 +6,7 @@ package tfe
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"

--- a/tfe/resource_tfe_project.go
+++ b/tfe/resource_tfe_project.go
@@ -6,7 +6,7 @@ package tfe
 import (
 	"context"
 	"errors"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/tfe/resource_tfe_registry_module.go
+++ b/tfe/resource_tfe_registry_module.go
@@ -6,7 +6,7 @@ package tfe
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/tfe/resource_tfe_run_trigger.go
+++ b/tfe/resource_tfe_run_trigger.go
@@ -5,7 +5,7 @@ package tfe
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/tfe/resource_tfe_sentinel_policy.go
+++ b/tfe/resource_tfe_sentinel_policy.go
@@ -6,7 +6,7 @@ package tfe
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"

--- a/tfe/resource_tfe_ssh_key.go
+++ b/tfe/resource_tfe_ssh_key.go
@@ -5,7 +5,7 @@ package tfe
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/tfe/resource_tfe_team.go
+++ b/tfe/resource_tfe_team.go
@@ -6,7 +6,7 @@ package tfe
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/tfe/resource_tfe_team_access.go
+++ b/tfe/resource_tfe_team_access.go
@@ -6,7 +6,7 @@ package tfe
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"

--- a/tfe/resource_tfe_team_member.go
+++ b/tfe/resource_tfe_team_member.go
@@ -5,7 +5,7 @@ package tfe
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"

--- a/tfe/resource_tfe_team_members.go
+++ b/tfe/resource_tfe_team_members.go
@@ -6,7 +6,7 @@ package tfe
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/tfe/resource_tfe_team_organization_member.go
+++ b/tfe/resource_tfe_team_organization_member.go
@@ -6,7 +6,7 @@ package tfe
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"

--- a/tfe/resource_tfe_team_organization_members.go
+++ b/tfe/resource_tfe_team_organization_members.go
@@ -6,7 +6,7 @@ package tfe
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/tfe/resource_tfe_team_project_access.go
+++ b/tfe/resource_tfe_team_project_access.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 func resourceTFETeamProjectAccess() *schema.Resource {

--- a/tfe/resource_tfe_team_token.go
+++ b/tfe/resource_tfe_team_token.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/tfe/resource_tfe_terraform_version.go
+++ b/tfe/resource_tfe_terraform_version.go
@@ -6,7 +6,7 @@ package tfe
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"

--- a/tfe/resource_tfe_variable.go
+++ b/tfe/resource_tfe_variable.go
@@ -6,7 +6,7 @@ package tfe
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"

--- a/tfe/resource_tfe_variable_set.go
+++ b/tfe/resource_tfe_variable_set.go
@@ -5,7 +5,7 @@ package tfe
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 
 	tfe "github.com/hashicorp/go-tfe"

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -6,7 +6,7 @@ package tfe
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/url"
 	"regexp"
 	"strings"

--- a/tfe/resource_tfe_workspace_policy_set.go
+++ b/tfe/resource_tfe_workspace_policy_set.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"

--- a/tfe/resource_tfe_workspace_run_task.go
+++ b/tfe/resource_tfe_workspace_run_task.go
@@ -6,7 +6,7 @@ package tfe
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"math/rand"
 	"os"
 	"regexp"

--- a/tfe/resource_tfe_workspace_variable_set.go
+++ b/tfe/resource_tfe_workspace_variable_set.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"

--- a/tfe/tfe_sweeper_test.go
+++ b/tfe/tfe_sweeper_test.go
@@ -6,7 +6,7 @@ package tfe
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 


### PR DESCRIPTION
Use logrus for logging instead of standard log library

[_Created by Sourcegraph batch change `admin/use-logrus-in-terraform-providers`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/use-logrus-in-terraform-providers)